### PR TITLE
運営者情報（お問い合わせ先）ページを実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,6 +15,7 @@
  */
 
 *{
+  margin: 0px;
   box-sizing: border-box;
 }
 

--- a/app/assets/stylesheets/application_data/index.css
+++ b/app/assets/stylesheets/application_data/index.css
@@ -3,7 +3,7 @@
   height: 100vh;
 }
 
-.head {
+.header {
   width: 100vw;
   height: 25vh;
   background-color: #33CCFF;
@@ -58,4 +58,5 @@ footer {
   text-align: center;
   border-top: solid 1px black;
   background-color: #FFFFCC;
+  bottom: 0px;
 }

--- a/app/assets/stylesheets/application_data/operator_info.css
+++ b/app/assets/stylesheets/application_data/operator_info.css
@@ -1,0 +1,32 @@
+.operator-info-body {
+  height: 60vh;
+  width: 100vw;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+}
+
+.operator-info-main {
+  height: 100%;
+  width: 650px;
+}
+
+.operator-info-title {
+  margin: 10px 0px;
+}
+
+.operator-info-table {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.operator-info-item, .operator-info-content {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  text-align: center;
+}
+
+.operator-info-item {
+  width: 150px;
+}

--- a/app/assets/stylesheets/shared/footer.css
+++ b/app/assets/stylesheets/shared/footer.css
@@ -1,16 +1,8 @@
 .contact-us {
-  display: flex;
+  display: inline-block;
   justify-content: center;
-}
-
-ul {
-  list-style: none;
 }
 
 .footer-title {
   margin-top: 15px;
-}
-
-.footer-list {
-  margin: 5px 10px;
 }

--- a/app/controllers/application_data_controller.rb
+++ b/app/controllers/application_data_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationDataController < ApplicationController
   require "wareki"
   require "date"
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :operator_info]
 
   def index
   end
@@ -26,6 +26,9 @@ class ApplicationDataController < ApplicationController
     else
       render :new
     end
+  end
+
+  def operator_info
   end
 
   private

--- a/app/views/application_data/index.html.erb
+++ b/app/views/application_data/index.html.erb
@@ -1,5 +1,5 @@
 <div class="wrapper">
-  <div class="head">
+  <div class="header">
     <%= render "shared/header" %>
   </div>
 

--- a/app/views/application_data/operator_info.html.erb
+++ b/app/views/application_data/operator_info.html.erb
@@ -1,0 +1,34 @@
+<div class="operator-info-wrapper">
+  <div class="header">
+    <%= render "shared/header" %>
+  </div>
+
+  <div class="operator-info-body">
+    <div class="operator-info-main">
+      <div class="operator-info-title">
+       登記推進委員会
+      </div>
+      <div class="operator-info-table">
+        <table border="1">
+          <tr class="operator-info-tr">
+            <th class="operator-info-item">運営者</th>
+            <th class="operator-info-content">佐賀達也</th>
+          </tr>
+          <tr class="operator-info-tr">
+            <td class="operator-info-item">経歴</td>
+            <td class="operator-info-content">司法書士業務に9年ほど携わっていた元司法書士です。</td>
+          </tr>
+          <tr class="operator-info-tr">
+            <td class="operator-info-item">メールアドレス</td>
+            <td class="operator-info-content">t.saga@yahoo.ne.jp</td>
+          </tr>
+        </table>
+      </div>
+      <%= link_to "トップページに戻る", root_path %>
+    </div>
+  </div>
+
+  <div class="footer">
+    <%= render "shared/footer" %>
+  </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer>
   <h5 class="footer-title">本サイトについて</h5>
   <div class="contact-us">
-    <%= link_to "運営者情報（お問い合わせ先）", "#" %>
+    <%= link_to "運営者情報（お問い合わせ先）", operator_info_application_data_path %>
   </div>
 </footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,6 @@
 <footer>
   <h5 class="footer-title">本サイトについて</h5>
-  <ul class="contact-us">
-    <li class="footer-list"><%= link_to "お問い合わせ", "#" %></li>
-    <li class="footer-list"><%= link_to "運営者情報", "#" %></li>
-  </ul>
+  <div class="contact-us">
+    <%= link_to "運営者情報（お問い合わせ先）", "#" %>
+  </div>
 </footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,9 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "application_data#index"
   resources :application_data, only: [:index, :new, :create, :destroy]
+  resources :application_data do
+    collection do
+      get "operator_info"
+    end
+  end
 end


### PR DESCRIPTION
# what
運営者情報（お問い合わせ先）ページを実装

# why
- ユーザーがサイトの信用性を確認できるようにするため
- ユーザーが運営者に不具合等を報告できるようにするため